### PR TITLE
Release JS React Native v1.12.0

### DIFF
--- a/js/react-native/CHANGELOG.md
+++ b/js/react-native/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.12.0 (Apr 24, 2026) with ChatSDK ^4.22.0
+
+
+### Minor Changes
+
+- Add `icons` prop to customize icon components via a partial icon registry
+
+### Patch Changes
+
+- Fix contrast and accessibility in FeedbackModal and inline feedback pill components
+
+
 ## v1.11.1 (Apr 17, 2026) with ChatSDK ^4.22.0
 
 


### PR DESCRIPTION
Automated release for JS React Native v1.12.0 (CHANGELOG + docs)