### PR TITLE
docs: add Steward JS changelog entries

### DIFF
--- a/js/cdn/CHANGELOG.md
+++ b/js/cdn/CHANGELOG.md
@@ -30,12 +30,16 @@
 ## v1.22.0 (Apr 13, 2026) with ChatSDK ^4.22.0
 
 
-### Patch Changes
+### Minor Changes
 
 - Steward support: Introduced Steward, an agentic workflow layer that handles structured customer requests within the chat widget
   - The widget title now updates dynamically to reflect the current Steward state (e.g., processing, completed, cancelled)
   - Users can cancel an active Steward request directly from the chat interface
   - Users can demand a handoff to a human agent at any point during a Steward workflow
+
+
+### Patch Changes
+
 - Updated dependencies
   - @sendbird/ai-agent-messenger-react@1.22.0
 

--- a/js/cdn/CHANGELOG.md
+++ b/js/cdn/CHANGELOG.md
@@ -32,6 +32,10 @@
 
 ### Patch Changes
 
+- Steward support: Introduced Steward, an agentic workflow layer that handles structured customer requests within the chat widget
+  - The widget title now updates dynamically to reflect the current Steward state (e.g., processing, completed, cancelled)
+  - Users can cancel an active Steward request directly from the chat interface
+  - Users can demand a handoff to a human agent at any point during a Steward workflow
 - Updated dependencies
   - @sendbird/ai-agent-messenger-react@1.22.0
 

--- a/js/react-native/CHANGELOG.md
+++ b/js/react-native/CHANGELOG.md
@@ -44,16 +44,16 @@
 
 ### Minor Changes
 
+- Steward support: Introduced Steward, an agentic workflow layer that handles structured customer requests within the chat widget
+  - The widget title now updates dynamically to reflect the current Steward state (e.g., processing, completed, cancelled)
+  - Users can cancel an active Steward request directly from the chat interface
+  - Users can demand a handoff to a human agent at any point during a Steward workflow
 - Add `colors` prop to `MessengerThemeContext` and provider container theme props for per-value color overrides
 - Add `AccessibilityAnnouncerContext` for platform-native accessibility announcements
 - Add `ConversationAnnouncementsContext` for coordinating status, typing, and screen entry announcements
 - Add `useA11y` hook for accessibility attributes on conversation UI elements
 - Add status, typing, and screen entry announcement hooks
 - Add `useReducedMotion` hook to respect user motion preferences
-- Steward support: Introduced Steward, an agentic workflow layer that handles structured customer requests within the chat widget
-  - The widget title now updates dynamically to reflect the current Steward state (e.g., processing, completed, cancelled)
-  - Users can cancel an active Steward request directly from the chat interface
-  - Users can demand a handoff to a human agent at any point during a Steward workflow
 
 
 ## v1.10.3 (Apr 03, 2026) with ChatSDK ^4.22.0

--- a/js/react-native/CHANGELOG.md
+++ b/js/react-native/CHANGELOG.md
@@ -50,6 +50,10 @@
 - Add `useA11y` hook for accessibility attributes on conversation UI elements
 - Add status, typing, and screen entry announcement hooks
 - Add `useReducedMotion` hook to respect user motion preferences
+- Steward support: Introduced Steward, an agentic workflow layer that handles structured customer requests within the chat widget
+  - The widget title now updates dynamically to reflect the current Steward state (e.g., processing, completed, cancelled)
+  - Users can cancel an active Steward request directly from the chat interface
+  - Users can demand a handoff to a human agent at any point during a Steward workflow
 
 
 ## v1.10.3 (Apr 03, 2026) with ChatSDK ^4.22.0

--- a/js/react/CHANGELOG.md
+++ b/js/react/CHANGELOG.md
@@ -66,6 +66,10 @@
 - Add status, typing, and screen entry announcement hooks
 - Add `useReducedMotion` hook to respect user motion preferences
 - Add new a11y localization string keys
+- Steward support: Introduced Steward, an agentic workflow layer that handles structured customer requests within the chat widget
+  - The widget title now updates dynamically to reflect the current Steward state (e.g., processing, completed, cancelled)
+  - Users can cancel an active Steward request directly from the chat interface
+  - Users can demand a handoff to a human agent at any point during a Steward workflow
 
 
 ## v1.21.3 (Apr 03, 2026) with ChatSDK ^4.22.0

--- a/js/react/CHANGELOG.md
+++ b/js/react/CHANGELOG.md
@@ -57,6 +57,10 @@
 
 ### Minor Changes
 
+- Steward support: Introduced Steward, an agentic workflow layer that handles structured customer requests within the chat widget
+  - The widget title now updates dynamically to reflect the current Steward state (e.g., processing, completed, cancelled)
+  - Users can cancel an active Steward request directly from the chat interface
+  - Users can demand a handoff to a human agent at any point during a Steward workflow
 - Add `colors` prop to `MessengerThemeContext` and provider container theme props for per-value color overrides
 - Add `AriaLiveRegionContext` for ARIA live region screen reader announcements
 - Add `ConversationAnnouncementsContext` for coordinating status, typing, and screen entry announcements
@@ -66,10 +70,6 @@
 - Add status, typing, and screen entry announcement hooks
 - Add `useReducedMotion` hook to respect user motion preferences
 - Add new a11y localization string keys
-- Steward support: Introduced Steward, an agentic workflow layer that handles structured customer requests within the chat widget
-  - The widget title now updates dynamically to reflect the current Steward state (e.g., processing, completed, cancelled)
-  - Users can cancel an active Steward request directly from the chat interface
-  - Users can demand a handoff to a human agent at any point during a Steward workflow
 
 
 ## v1.21.3 (Apr 03, 2026) with ChatSDK ^4.22.0


### PR DESCRIPTION
## Summary
- Adds the Steward support release note to the JS React `v1.22.0` changelog section.
- Adds the same Steward support release note to the JS React Native `v1.11.0` changelog section.
- Adds the same Steward support release note to the JS CDN `v1.22.0` changelog section.
- Mirrors the Steward behavior already documented in the iOS changelog.

## Verification
- `git diff --check`