### PR TITLE
fix: pass source PR metadata to docs sync

### DIFF
--- a/.github/workflows/notify-docs-sync.yml
+++ b/.github/workflows/notify-docs-sync.yml
@@ -14,8 +14,39 @@ jobs:
       - name: Trigger docs sync via repository_dispatch
         env:
           PAT: ${{ secrets.SDK_GH_BOT1_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
+
+          if [ -z "$MERGE_COMMIT_SHA" ] || [ "$MERGE_COMMIT_SHA" = "null" ]; then
+            echo "::error::Missing pull request merge commit SHA"
+            exit 1
+          fi
+
+          PAYLOAD=$(jq -nc \
+            --arg pr_number "$PR_NUMBER" \
+            --arg merge_commit_sha "$MERGE_COMMIT_SHA" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg base_sha "$BASE_SHA" \
+            --arg head_ref "$HEAD_REF" \
+            --arg base_ref "$BASE_REF" \
+            '{
+              event_type: "sync-sdk-docs",
+              client_payload: {
+                source_repo: "sendbird/delight-ai-agent",
+                pr_number: ($pr_number | tonumber),
+                merge_commit_sha: $merge_commit_sha,
+                head_sha: $head_sha,
+                base_sha: $base_sha,
+                head_ref: $head_ref,
+                base_ref: $base_ref
+              }
+            }')
 
           curl -L \
             -X POST \
@@ -23,4 +54,4 @@ jobs:
             -H "Authorization: Bearer $PAT" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/sendbird/delight-ai-docs/dispatches \
-            -d '{"event_type":"sync-sdk-docs"}'
+            -d "$PAYLOAD"


### PR DESCRIPTION
## Summary
- Send the merged delight-ai-agent PR metadata in the docs sync repository_dispatch payload.
- Include the source PR number and merge commit SHA so the docs repo can sync the exact PR that triggered the event.
- Fail fast if GitHub does not provide a merge commit SHA for a merged PR.

## Validation
- ruby YAML parse for .github/workflows/notify-docs-sync.yml
- actionlint .github/workflows/notify-docs-sync.yml


https://github.com/sendbird/delight-ai-docs/pull/143