### PR TITLE
Release JS Cdn v1.26.1

### DIFF
--- a/js/cdn/CHANGELOG.md
+++ b/js/cdn/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.26.1 (May 15, 2026) with ChatSDK ^4.22.3
+
+
+### Patch Changes
+
+- Updated dependencies
+  - @sendbird/ai-agent-messenger-react@1.26.1
+
+
 ## v1.26.0 (May 13, 2026) with ChatSDK ^4.22.3
 
 


### PR DESCRIPTION
Automated release for JS Cdn v1.26.1 (CHANGELOG + docs + discussion platform docs)