### PR TITLE
Release JS React Native v1.15.0

### DIFF
--- a/.discussions/conversation/customize-memory-dialog-style/react-native.md
+++ b/.discussions/conversation/customize-memory-dialog-style/react-native.md
@@ -9,11 +9,16 @@ The memory dialog supports separate color tokens for the title, markdown body, m
 ### Example
 
 ```tsx
+import { createMMKV } from 'react-native-mmkv';
 import {
   AIAgentProviderContainer,
   AnonymousSessionInfo,
   Conversation,
 } from '@sendbird/ai-agent-messenger-react-native';
+
+const nativeModules = {
+  mmkv: createMMKV(),
+};
 
 function App() {
   return (

--- a/.discussions/launcher/customize-messenger-launcher-layout/react-native.md
+++ b/.discussions/launcher/customize-messenger-launcher-layout/react-native.md
@@ -4,6 +4,14 @@
 
 You can customize the `FixedMessenger` layout using `FixedMessenger.Style` and `windowMode` props.
 
+Before using this example, install the required peer dependencies used by the provider and storage example:
+
+```sh
+pnpm add react-native-safe-area-context react-native-mmkv
+```
+
+Attachment features require additional picker or permission modules only when you configure those native adapters.
+
 ### Configuration Options
 
 **FixedMessenger Props:**
@@ -12,7 +20,7 @@ You can customize the `FixedMessenger` layout using `FixedMessenger.Style` and `
 | -------------- | -------- | ------- | ---------------------------------------- | ------------------------------------- |
 | `entryPoint`   | `string` | `'Conversation'` | Initial screen when launcher is clicked | `'Conversation'`, `'ConversationList'` |
 | `windowMode`   | `string` | `'floating'` | Display mode for the messenger window | `'floating'`, `'fullscreen'`          |
-| `fullscreenInsets` | `object` | `{ top: 0, left: 0, right: 0, bottom: 0 }` | Insets for fullscreen mode to handle safe areas | `{ top?, left?, right?, bottom? }` in pixels |
+| `fullscreenInsets` | `object` | Device safe-area insets | Insets for fullscreen mode. Passed values override the corresponding safe-area inset. | `{ top?, left?, right?, bottom? }` in pixels |
 | `edgeToEdgeEnabled` | `boolean` | `true` | (Android only) Enable edge-to-edge display, bottom inset considered when keyboard opens | `true`, `false` |
 
 **FixedMessenger.Style Properties:**
@@ -27,18 +35,34 @@ You can customize the `FixedMessenger` layout using `FixedMessenger.Style` and `
 ### Example
 
 ```tsx
-import { FixedMessenger } from '@sendbird/ai-agent-messenger-react-native';
+import { createMMKV } from 'react-native-mmkv';
+import {
+  AIAgentProviderContainer,
+  AnonymousSessionInfo,
+  FixedMessenger,
+} from '@sendbird/ai-agent-messenger-react-native';
+
+const nativeModules = {
+  mmkv: createMMKV(),
+};
 
 function App() {
   return (
-    <FixedMessenger windowMode={'floating'}>
-      <FixedMessenger.Style
-        position={'end-bottom'}
-        launcherSize={56}
-        margin={{ start: 20, end: 20, top: 20, bottom: 20 }}
-        spacing={12}
-      />
-    </FixedMessenger>
+    <AIAgentProviderContainer
+      appId={'YOUR_APP_ID'}
+      aiAgentId={'YOUR_AI_AGENT_ID'}
+      nativeModules={nativeModules}
+      userSessionInfo={new AnonymousSessionInfo()}
+    >
+      <FixedMessenger windowMode={'floating'}>
+        <FixedMessenger.Style
+          position={'end-bottom'}
+          launcherSize={56}
+          margin={{ start: 20, end: 20, top: 20, bottom: 20 }}
+          spacing={12}
+        />
+      </FixedMessenger>
+    </AIAgentProviderContainer>
   );
 }
 ```

--- a/js/react-native/CHANGELOG.md
+++ b/js/react-native/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## v1.15.0 (May 20, 2026) with ChatSDK ^4.22.3
+
+
+### Minor Changes
+
+- Add `conversation.list.markdownImageRenderMode` config option to hide incomplete markdown images while a message is streaming in the conversation
+
+```tsx
+import { AIAgentProviderContainer, FixedMessenger } from '@sendbird/ai-agent-messenger-react-native';
+
+<AIAgentProviderContainer
+  appId={'YOUR_APP_ID'}
+  aiAgentId={'YOUR_AI_AGENT_ID'}
+  userSessionInfo={userSessionInfo}
+  nativeModules={nativeModules}
+  config={{ conversation: { list: { markdownImageRenderMode: 'complete-only' } } }}
+>
+  <FixedMessenger />
+</AIAgentProviderContainer>;
+```
+
+- Group conversation list options under `conversation.list` (`isTalkToAgentViewEnabled`, `scrollMode`, `newMessageIndicatorEnabled`, `senderAvatarEnabled`); the legacy flat keys on `conversation` are still accepted and marked deprecated
+
+### Patch Changes
+
+- Fix conversation list screen entry not being announced to screen readers
+- Fix accessibility labels and hints for the close-messenger button across all supported languages
+- Fix accessibility for CSAT survey rating options, follow-up inputs, and radio controls
+- Fix accessibility labels and live-region announcements in the conversation list screen
+- Fix accessibility labels and hints for conversation screen header controls (close, menu, handoff, title)
+- Fix accessibility for form error labels and text inputs
+- Fix accessibility hint for the launcher button
+
+
 ## v1.14.1 (May 15, 2026) with ChatSDK ^4.22.3
 
 


### PR DESCRIPTION
Automated release for JS React Native v1.15.0 (CHANGELOG + docs + discussion platform docs)