### PR TITLE
Release JS React v1.28.0

### DIFF
--- a/.discussions/conversation/handle-link-taps/react.md
+++ b/.discussions/conversation/handle-link-taps/react.md
@@ -2,10 +2,42 @@
 
 ## How to handle link clicks in conversation messages
 
-There is no public hook to intercept link clicks inside conversation message text at this time.
+Intercept link clicks the SDK opens — markdown links, admin-message URLs, citations, CTA buttons, and file-message file-preview clicks — through the `handlers.onClickLink` callback on `AgentProviderContainer`.
 
-**Default behavior**
-- Incoming text messages render Markdown links through the SDK's internal Markdown renderer and open in a new tab.
-- Outgoing text messages do not render Markdown; URLs are not converted into `<a>` tags by the SDK.
+### Example
 
-If you need a programmatic link-click handler, please file a feature request so the SDK can expose a public Markdown renderer override or a link-click callback. Until then, do not replace the message body to inject DOM listeners; that path drops the SDK's text, file, media, multi-file, message-template, form, and citation rendering branches.
+```tsx
+import { AgentProviderContainer, Conversation } from '@sendbird/ai-agent-messenger-react';
+
+export const App = () => {
+  return (
+    <AgentProviderContainer
+      appId={'YOUR_APP_ID'}
+      aiAgentId={'YOUR_AI_AGENT_ID'}
+      handlers={{
+        onClickLink: ({ url }) => {
+          // analytics
+          analytics.track('agent_link_click', { url });
+
+          // in-app navigation for custom schemes
+          if (url.startsWith('myapp://')) {
+            router.push(url);
+            return;
+          }
+
+          // default behavior
+          window.open(url, '_blank', 'noopener,noreferrer');
+        },
+      }}
+    >
+      <Conversation />
+    </AgentProviderContainer>
+  );
+};
+```
+
+### Notes
+
+- Without `onClickLink`, the SDK falls back to `window.open(url, '_blank', 'noopener,noreferrer')`. If the URL has no protocol, the default prepends `https://`. Customer handlers receive the raw URL.
+- The MediaViewer's download button is intentionally excluded — it keeps native `<a href download>` behavior so browser-side downloads continue working without a custom handler.
+- If you replace message/layout slots and receive message props, slot-level callbacks (`onClickCTA`, `onClickCitation`, `onClickMedia`, `onClickFile`) still override that slot's behavior entirely and take precedence over `onClickLink`. `onClickLink` is the "last default" — used when no slot-level override is supplied.

--- a/js/react/CHANGELOG.md
+++ b/js/react/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v1.28.0 (May 22, 2026) with ChatSDK ^4.22.3
+
+
+### Minor Changes
+
+- Add `handlers.onClickLink` for intercepting link navigation (markdown links, admin-message URLs, citation links, CTA buttons, and non-media file-preview clicks); falls back to `window.open` when omitted
+
+```tsx
+import { AgentProviderContainer } from '@sendbird/ai-agent-messenger-react';
+
+<AgentProviderContainer
+  handlers={{
+    onClickLink: ({ url }) => {
+      // custom analytics or deep-link handling
+      window.open(url, '_blank');
+    },
+  }}
+/>;
+```
+
+
 ## v1.27.0 (May 20, 2026) with ChatSDK ^4.22.3
 
 


### PR DESCRIPTION
Automated release for JS React v1.28.0 (CHANGELOG + docs + discussion platform docs)