### PR TITLE
Release JS React Native v1.17.0

### DIFF
--- a/js/react-native/CHANGELOG.md
+++ b/js/react-native/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v1.17.0 (May 27, 2026) with ChatSDK ^4.22.4
+
+
+### Minor Changes
+
+- Improve accessibility for media viewer, bottom sheet, confirm dialog, and conversation screens with modal focus trapping, initial focus on open, and escape gesture support for screen reader users
+- Fix media viewer not opening when the initial file index is out of bounds
+- Add `a11y_file_selected` and `a11y_file_remove_button` to the React Native `StringSet` for customizing accessibility labels on file attachment previews
+- Add `IncomingMessageLayout.Challenge` slot for customizing challenge message rendering and `onSendChallengeAction` handler for responding to challenge messages
+- Add opt-in `launcher.unreadBadgeEnabled` config that shows a red-dot badge on the closed launcher when AI agent channels have unread messages; the count is fetched on connect/reconnect (not polled)
+
+```tsx
+import { AIAgentProviderContainer, FixedMessenger } from '@sendbird/ai-agent-messenger-react-native';
+
+<AIAgentProviderContainer
+  appId="YOUR_APP_ID"
+  aiAgentId="YOUR_AI_AGENT_ID"
+  config={{ launcher: { unreadBadgeEnabled: true } }}
+>
+  <FixedMessenger />
+</AIAgentProviderContainer>;
+```
+
+
 ## v1.16.0 (May 22, 2026) with ChatSDK ^4.22.3
 
 

--- a/js/react-native/docs/MULTILANGUAGE.md
+++ b/js/react-native/docs/MULTILANGUAGE.md
@@ -109,6 +109,8 @@ function App() {
     common: { /* ... */ },
     feedback: { /* ... */ },
     handoff: { /* ... */ },
+    memory: { /* ... */ },
+    connection_delay: { /* ... */ },
   }}
 >
   <FixedMessenger />

--- a/js/react-native/docs/README.md
+++ b/js/react-native/docs/README.md
@@ -34,7 +34,7 @@ You can find them under the **Channels** > **Messenger** menu on the Delight AI 
 
 - React >= 18.0.0
 - React Native >= 0.80.0
-- @sendbird/chat ^4.22.0
+- @sendbird/chat ^4.22.3
 - react-native-mmkv >= 3.0.0
 - react-native-safe-area-context >= 5.0.0
 - date-fns >= 4.0.0


### PR DESCRIPTION
Automated release for JS React Native v1.17.0 (CHANGELOG + docs + discussion platform docs)