### PR TITLE
Release JS React Native v1.19.1

### DIFF
--- a/js/react-native/CHANGELOG.md
+++ b/js/react-native/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.19.1 (Jun 09, 2026) with ChatSDK ^4.22.5
+
+
+### Patch Changes
+
+- Fix modal content rendering outside the messenger context boundary, which prevented messenger context hooks from being accessible inside modals
+- Fix date separator rendering order in inverted message list
+
+
 ## v1.19.0 (Jun 04, 2026) with ChatSDK ^4.22.5
 
 

--- a/js/react-native/docs/README.md
+++ b/js/react-native/docs/README.md
@@ -34,7 +34,7 @@ You can find them under the **Channels** > **Messenger** menu on the Delight AI 
 
 - React >= 18.0.0
 - React Native >= 0.80.0
-- @sendbird/chat ^4.22.3
+- @sendbird/chat ^4.22.5
 - react-native-mmkv >= 3.0.0
 - react-native-safe-area-context >= 5.0.0
 - date-fns >= 4.0.0


### PR DESCRIPTION
Automated release for JS React Native v1.19.1 (CHANGELOG + docs + discussion platform docs)