### PR TITLE
Release JS Cdn v1.32.0

### DIFF
--- a/js/cdn/CHANGELOG.md
+++ b/js/cdn/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.32.0 (Jun 10, 2026) with ChatSDK ^4.22.5
+
+
+### Patch Changes
+
+- Updated dependencies
+  - @sendbird/ai-agent-messenger-react@1.32.0
+
+
 ## v1.31.1 (Jun 09, 2026) with ChatSDK ^4.22.5
 
 


### PR DESCRIPTION
Automated release for JS Cdn v1.32.0 (CHANGELOG + docs + discussion platform docs)