### PR TITLE
Release JS React Native v1.20.0

### DIFF
--- a/js/react-native/CHANGELOG.md
+++ b/js/react-native/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v1.20.0 (Jun 10, 2026) with ChatSDK ^4.22.5
+
+
+### Minor Changes
+
+- Add `FixedMessenger.Conversation` and `FixedMessenger.ConversationList` for replacing the default conversation and conversation-list views with custom components
+
+```tsx
+import {
+  type ConversationListProps,
+  type ConversationProps,
+  FixedMessenger,
+} from '@sendbird/ai-agent-messenger-react-native';
+
+const CustomConversation = (props: ConversationProps) => <MyConversation {...props} />;
+const CustomConversationList = (props: ConversationListProps) => <MyConversationList {...props} />;
+<FixedMessenger appId={'APP_ID'} aiAgentId={'AGENT_ID'}>
+  <FixedMessenger.Conversation component={CustomConversation} />
+  <FixedMessenger.ConversationList component={CustomConversationList} />
+</FixedMessenger>;
+```
+
+### Patch Changes
+
+- Fix custom launcher images rendering smaller than the launcher button and not being clipped to the circular launcher border
+
+
 ## v1.19.1 (Jun 09, 2026) with ChatSDK ^4.22.5
 
 


### PR DESCRIPTION
Automated release for JS React Native v1.20.0 (CHANGELOG + docs + discussion platform docs)