### PR TITLE
Release JS Cdn v1.33.0

### DIFF
--- a/js/cdn/CHANGELOG.md
+++ b/js/cdn/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.33.0 (Jun 17, 2026) with ChatSDK ^4.22.5
+
+
+### Patch Changes
+
+- Updated dependencies
+  - @sendbird/ai-agent-messenger-react@1.33.0
+
+
 ## v1.32.0 (Jun 10, 2026) with ChatSDK ^4.22.5
 
 

--- a/js/cdn/docs/MULTILANGUAGE.md
+++ b/js/cdn/docs/MULTILANGUAGE.md
@@ -258,7 +258,7 @@ A11Y_IMAGE_VIEWER_NEXT: 'Next image',
 A11Y_IMAGE_VIEWER_DOWNLOAD: 'Download image',
 A11Y_ATTACH_FILE: 'Attach file',
 
-SCROLL_TO_NEW_MESSAGES_LABEL: (messages) => 'New message',
+SCROLL_TO_NEW_MESSAGES_LABEL: () => 'New message',
 
 // Message Input
 MESSAGE_INPUT__PLACE_HOLDER__STEWARD: 'Processing your request...',

--- a/js/cdn/docs/features/conversations.md
+++ b/js/cdn/docs/features/conversations.md
@@ -235,9 +235,15 @@ messenger.updateConfig({
   countryCode: 'KR',
   theme: {
     palette: {
-      primary: '#6210CC'
-    }
-  }
+      primary: {
+        extraDark: '#3A0A7A',
+        dark: '#4E0FAA',
+        main: '#6210CC',
+        light: '#8B4DDB',
+        extraLight: '#C3A6ED',
+      },
+    },
+  },
 });
 ```
 


### PR DESCRIPTION
Automated release for JS Cdn v1.33.0 (CHANGELOG + docs + discussion platform docs)