### PR TITLE
Release JS React Native v1.21.0

### DIFF
--- a/js/react-native/CHANGELOG.md
+++ b/js/react-native/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.21.0 (Jun 17, 2026) with ChatSDK ^4.22.5
+
+
+### Minor Changes
+
+- Add `conversationStatsEnabled` prop to `Conversation` for controlling stats collection when building custom conversation navigation
+- Add `conversationListStatsEnabled` prop to `ConversationList` for controlling stats collection when building custom conversation list navigation
+
+### Patch Changes
+
+- Fix date dividers so consecutive welcome messages spanning multiple days stay grouped with one divider.
+- Fix avatar and channel cover images not falling back to the placeholder icon when the image URL fails to load
+- Fix date dividers so consecutive welcome messages spanning multiple days stay grouped with one divider.
+
+
 ## v1.20.0 (Jun 10, 2026) with ChatSDK ^4.22.5
 
 

--- a/js/react-native/docs/features/conversations.md
+++ b/js/react-native/docs/features/conversations.md
@@ -525,6 +525,8 @@ Configuration options for the `AIAgentProviderContainer` component. This compone
 | `context` | Record<string, string> | - | Context object for personalized AI agent responses |
 | `queryParams` | AIAgentQueryParams | - | Global default query parameters for AI agent |
 | `config` | DeepPartial<AIAgentConfig> | - | Global default configuration for AI agent |
+| `handlers` | AgentClientHandlers | - | Event handlers for the AI agent client |
+| `icons` | IconRegistry | - | Custom icon registry for the AI agent client |
 
 ### FixedMessenger Props
 


### PR DESCRIPTION
Automated release for JS React Native v1.21.0 (CHANGELOG + docs + discussion platform docs)