### PR TITLE
Release JS Cdn v1.34.0

### DIFF
--- a/js/cdn/CHANGELOG.md
+++ b/js/cdn/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.34.0 (Jun 25, 2026) with ChatSDK ^4.22.5
+
+
+### Patch Changes
+
+- Updated dependencies
+  - @sendbird/ai-agent-messenger-react@1.34.0
+
+
 ## v1.33.0 (Jun 17, 2026) with ChatSDK ^4.22.5
 
 


### PR DESCRIPTION
Automated release for JS Cdn v1.34.0 (CHANGELOG + docs + discussion platform docs)