### PR TITLE
Release JS React v1.35.1

### DIFF
--- a/js/react/CHANGELOG.md
+++ b/js/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.35.1 (Jul 13, 2026) with ChatSDK ^4.22.6
+
+
+### Patch Changes
+
+- `FixedMessenger` now initializes the conversation when it is opened and the conversation is viewed
+
+
 ## v1.35.0 (Jul 09, 2026) with ChatSDK ^4.22.6
 
 


### PR DESCRIPTION
Automated release for JS React v1.35.1 (CHANGELOG + docs + discussion platform docs)