### PR TITLE
Release JS React Native v1.24.1

### DIFF
--- a/js/react-native/CHANGELOG.md
+++ b/js/react-native/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.24.1 (Jul 13, 2026) with ChatSDK ^4.22.6
+
+
+### Patch Changes
+
+- `FixedMessenger` now initializes the conversation when it is opened and the conversation is viewed
+
+
 ## v1.24.0 (Jul 09, 2026) with ChatSDK ^4.22.6
 
 


### PR DESCRIPTION
Automated release for JS React Native v1.24.1 (CHANGELOG + docs + discussion platform docs)