### PR TITLE
Release JS Cdn v1.38.0

### DIFF
--- a/js/cdn/CHANGELOG.md
+++ b/js/cdn/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.38.0 (Jul 29, 2026) with ChatSDK ^4.22.9
+
+
+### Patch Changes
+
+- Updated dependencies
+  - @sendbird/ai-agent-messenger-react@1.38.0
+
+
 ## v1.37.0 (Jul 27, 2026) with ChatSDK ^4.22.9
 
 


### PR DESCRIPTION
Automated release for JS Cdn v1.38.0 (CHANGELOG + docs + discussion platform docs)