### PR TITLE
Release JS Cdn v1.39.1

### DIFF
--- a/js/cdn/CHANGELOG.md
+++ b/js/cdn/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.39.1 (Aug 13, 2026) with ChatSDK ^4.22.9
+
+
+### Patch Changes
+
+- Improve SDK usage logging
+- Updated dependencies
+  - @sendbird/ai-agent-messenger-react@1.39.1
+
+
 ## v1.39.0 (Aug 11, 2026) with ChatSDK ^4.22.9
 
 


### PR DESCRIPTION
Automated release for JS Cdn v1.39.1 (CHANGELOG + docs + discussion platform docs)