### PR TITLE
chore: update discussion numbers after sync

### DIFF
--- a/.discussions/conversation/conversation/meta.json
+++ b/.discussions/conversation/conversation/meta.json
@@ -8,5 +8,7 @@
     "🎨 React",
     "🎨 iOS"
   ],
-  "platforms": []
+  "platforms": [],
+  "discussion_number": 447,
+  "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/447"
 }


### PR DESCRIPTION
## Summary

Auto-generated PR to update `meta.json` files with discussion numbers after sync.

---
🤖 Generated with GitHub Actions