### PR TITLE
chore: update discussion numbers after sync

### DIFF
--- a/.discussions/conversation/customaize-message-suggested-replies/meta.json
+++ b/.discussions/conversation/customaize-message-suggested-replies/meta.json
@@ -8,5 +8,7 @@
     "🎨 React",
     "🎨 iOS"
   ],
-  "platforms": []
+  "platforms": [],
+  "discussion_number": 452,
+  "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/452"
 }


### PR DESCRIPTION
## Summary

Auto-generated PR to update `meta.json` files with discussion numbers after sync.

---
🤖 Generated with GitHub Actions