### PR TITLE
chore: render react-native platform for 20 discussions

### DIFF
--- a/.discussions/conversation-list/add-left-button-header/meta.json
+++ b/.discussions/conversation-list/add-left-button-header/meta.json
@@ -6,12 +6,14 @@
     "🎨 Header",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/76"
 }

--- a/.discussions/conversation-list/customize-footer-background/meta.json
+++ b/.discussions/conversation-list/customize-footer-background/meta.json
@@ -5,12 +5,14 @@
     "🎨 Conversation List",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/82"
 }

--- a/.discussions/conversation-list/customize-footer-text/meta.json
+++ b/.discussions/conversation-list/customize-footer-text/meta.json
@@ -5,12 +5,14 @@
     "🎨 Conversation List",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/88"
 }

--- a/.discussions/conversation-list/insert-custom-view/meta.json
+++ b/.discussions/conversation-list/insert-custom-view/meta.json
@@ -5,12 +5,14 @@
     "🎨 Conversation List",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/86"
 }

--- a/.discussions/conversation/custom-profile-visibility/meta.json
+++ b/.discussions/conversation/custom-profile-visibility/meta.json
@@ -7,12 +7,14 @@
     "🎨 List",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/119"
 }

--- a/.discussions/conversation/customize-date-separator-color/meta.json
+++ b/.discussions/conversation/customize-date-separator-color/meta.json
@@ -7,12 +7,14 @@
     "🎨 iOS",
     "🎨 Android",
     "🎨 React",
-    "🎨 Message"
+    "🎨 Message",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/136"
 }

--- a/.discussions/conversation/customize-header-alignment/meta.json
+++ b/.discussions/conversation/customize-header-alignment/meta.json
@@ -6,12 +6,14 @@
     "🎨 Header",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/134"
 }

--- a/.discussions/conversation/customize-header-left-right/meta.json
+++ b/.discussions/conversation/customize-header-left-right/meta.json
@@ -6,12 +6,14 @@
     "🎨 Header",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/128"
 }

--- a/.discussions/conversation/customize-header-title/meta.json
+++ b/.discussions/conversation/customize-header-title/meta.json
@@ -6,12 +6,14 @@
     "🎨 Header",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/131"
 }

--- a/.discussions/conversation/customize-input-area-background-color/meta.json
+++ b/.discussions/conversation/customize-input-area-background-color/meta.json
@@ -5,11 +5,13 @@
     "🎨 Conversation",
     "🎨 Input",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/80"
 }

--- a/.discussions/conversation/customize-message-bubble-max-width/meta.json
+++ b/.discussions/conversation/customize-message-bubble-max-width/meta.json
@@ -5,12 +5,14 @@
     "🎨 Conversation",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/89"
 }

--- a/.discussions/conversation/customize-message-position/meta.json
+++ b/.discussions/conversation/customize-message-position/meta.json
@@ -5,12 +5,14 @@
     "🎨 Conversation",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/92"
 }

--- a/.discussions/conversation/customize-sender-name-font/meta.json
+++ b/.discussions/conversation/customize-sender-name-font/meta.json
@@ -5,12 +5,14 @@
     "🎨 Conversation",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/90"
 }

--- a/.discussions/conversation/customize-sent-time-font/meta.json
+++ b/.discussions/conversation/customize-sent-time-font/meta.json
@@ -5,12 +5,14 @@
     "🎨 Conversation",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/91"
 }

--- a/.discussions/conversation/customize-time-label-color/meta.json
+++ b/.discussions/conversation/customize-time-label-color/meta.json
@@ -7,12 +7,14 @@
     "🎨 iOS",
     "🎨 Android",
     "🎨 React",
-    "🎨 Message"
+    "🎨 Message",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/135"
 }

--- a/.discussions/conversation/customize-typing-indicator/meta.json
+++ b/.discussions/conversation/customize-typing-indicator/meta.json
@@ -5,12 +5,14 @@
     "🎨 Conversation",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/79"
 }

--- a/.discussions/conversation/customize-username-color/meta.json
+++ b/.discussions/conversation/customize-username-color/meta.json
@@ -7,12 +7,14 @@
     "🎨 iOS",
     "🎨 Android",
     "🎨 React",
-    "🎨 Message"
+    "🎨 Message",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/137"
 }

--- a/.discussions/conversation/disable-powered-by-message/meta.json
+++ b/.discussions/conversation/disable-powered-by-message/meta.json
@@ -5,12 +5,14 @@
     "🎨 Conversation",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/78"
 }

--- a/.discussions/conversation/handle-link-taps/meta.json
+++ b/.discussions/conversation/handle-link-taps/meta.json
@@ -5,12 +5,14 @@
     "🎨 Conversation",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/93"
 }

--- a/.discussions/conversation/insert-custom-divider/meta.json
+++ b/.discussions/conversation/insert-custom-divider/meta.json
@@ -5,12 +5,14 @@
     "🎨 Conversation",
     "🎨 iOS",
     "🎨 Android",
-    "🎨 React"
+    "🎨 React",
+    "🎨 React-Native"
   ],
   "platforms": [
     "ios",
     "android",
-    "react"
+    "react",
+    "react-native"
   ],
   "html_url": "https://github.com/sendbird/delight-ai-agent/discussions/87"
 }


### PR DESCRIPTION
## Summary

Enables the `react-native` platform section for 20 existing discussions. Each one already has (or is about to have) a `react-native.md` body authored in `sendbird/ai-agent-js`.

- Adds `"react-native"` to `meta.platforms` and `"🎨 React-Native"` to `meta.labels` for 20 discussions
- No content changes here — the platform bodies are owned by `ai-agent-js` and land via the release sync

`.discussions/scripts/utils.js` renders one `<details>` block per entry in `meta.platforms`, so without this change the React Native docs are copied but never shown.

## ⚠️ Merge order

**Merge this only after the `ai-agent-js` PR below has been released and its `react-native.md` files have synced into this repo.**

`buildDiscussionContent()` emits `> This guide is coming soon. Stay tuned for updates!` for a listed platform whose file is missing — merging early would publish that placeholder on 20 discussions.

- ai-agent-js PR: https://github.com/sendbird/ai-agent-js/pull/1479

## Not included

| Discussion | Why |
| --- | --- |
| `conversation/customaize-message-suggested-replies` | `platforms: []` → already falls back to `default_platforms` (all four) |
| `conversation/customize-memory-dialog-style` | same |
| `launcher/customize-messenger-launcher-layout` | already lists `react-native` |
| `conversation-list/add-bottom-inset` | no React Native doc — no public RN API for it |
| `conversation-list/customize-list-item-view` | no React Native doc — `ConversationListItemLayout` is not exported from the RN package |
| `conversation-list/inject-custom-data` | same |

## Verification

- `node .discussions/scripts/build.js` against a tree with the `ai-agent-js` docs synced in: 26 discussions built, remaining `coming soon` placeholders are only Android/iOS
- Label spelling matches the existing `🎨 React-Native` used by `launcher/customize-messenger-launcher-layout` and `conversation/customize-memory-dialog-style`
