### PR TITLE
Release JS Cdn v1.42.0

### DIFF
--- a/js/cdn/CHANGELOG.md
+++ b/js/cdn/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.42.0 (Sep 07, 2026) with ChatSDK ^4.22.11
+
+
+### Patch Changes
+
+- Updated dependencies
+  - @sendbird/ai-agent-messenger-react@1.42.0
+
+
 ## v1.41.0 (Aug 28, 2026) with ChatSDK ^4.22.11
 
 


### PR DESCRIPTION
Automated release for JS Cdn v1.42.0 (CHANGELOG + docs + discussion platform docs)